### PR TITLE
[NSA-8937] Fix request status when org has no active approvers

### DIFF
--- a/src/app/overdueAllRequestsTypes/overdueRequests.js
+++ b/src/app/overdueAllRequestsTypes/overdueRequests.js
@@ -218,7 +218,7 @@ const overdueAllRequestsTypes = async () => {
   );
 
   logger.info(
-    "Updating outstanding servie requests to status 3 if organisation has no active approvers",
+    "Updating outstanding service requests to status 3 if organisation has no active approvers",
   );
   allOutstandingServSubServRequests =
     await updateRequestsWhereOrgHasNoActiveApprovers(

--- a/src/app/overdueAllRequestsTypes/overdueRequests.js
+++ b/src/app/overdueAllRequestsTypes/overdueRequests.js
@@ -88,7 +88,7 @@ const updateRequestsWhereOrgHasNoActiveApprovers = async (
       // If requests org has approvers then filter it into the list of requests that
       // will continue to be processed. If no approvers, we update the status and then
       // forget about it for the rest of this process.
-      if (activeUsers === undefined || activeUsers.length === 0) {
+      if (activeUsers.length === 0) {
         logger.info(
           `Request [${request.id}] for organisation [${request.org_id}] has no active approvers.  Setting to status 3`,
         );

--- a/src/app/overdueAllRequestsTypes/overdueRequests.js
+++ b/src/app/overdueAllRequestsTypes/overdueRequests.js
@@ -61,6 +61,71 @@ const listApproversReqToOverdue = async (
  *
  * @param {Array} outstandingRequests
  * @param {string} requestType
+ *
+ * Takes an array of outstanding requests and loops over them to check each one has
+ * at least 1 active approver in the organisation.
+ *
+ * If the organisation has 0 active approvers (either becuase it has 0, or because all
+ * the approvers it has have been deactivated), the request will be set to status 3 and
+ * will NOT be in the list of returned requests
+ */
+const updateRequestsWhereOrgHasNoActiveApprovers = async (
+  outstandingRequests,
+  requestType,
+) => {
+  logger.info(
+    `Looping over [${outstandingRequests.length}] outstanding requests of type [${requestType}] and checking if the org has active approvers`,
+  );
+  const remainingOutstandingRequests = [];
+  for (let i = 0; i < outstandingRequests.length; i += 1) {
+    const request = outstandingRequests[i];
+
+    const approverIds = await getApproversForOrg(request.org_id);
+    if (approverIds && approverIds.length >= 1) {
+      const approversDetails = await getUsersByIds(approverIds.join(","));
+      const activeUsers = approversDetails.filter((user) => user.status === 1);
+
+      // If requests org has approvers then filter it into the list of requests that
+      // will continue to be processed. If no approvers, we update the status and then
+      // forget about it for the rest of this process.
+      if (activeUsers === undefined || activeUsers.length === 0) {
+        logger.info(
+          `Request [${request.id}] for organisation [${request.org_id}] has no active approvers.  Setting to status 3`,
+        );
+        const updatedRequest = { status: 3 };
+        if (requestType === requestTypes.ORGANISATION_ACCESS) {
+          await updateUserOrgRequest(request.id, updatedRequest);
+        } else if (requestType === requestTypes.SERVICE_SUB_SERVICE_ACCESS) {
+          await updateUserServSubServRequest(request.id, updatedRequest);
+        }
+      } else {
+        logger.info(
+          `Request [${request.id}] for organisation [${request.org_id}] has active approvers`,
+        );
+        remainingOutstandingRequests.push(request);
+      }
+    } else {
+      logger.info(
+        `Request [${request.id}] for organisation [${request.org_id}] has no active approvers.  Setting to status 3`,
+      );
+      const updatedRequest = { status: 3 };
+      if (requestType === requestTypes.ORGANISATION_ACCESS) {
+        await updateUserOrgRequest(request.id, updatedRequest);
+      } else if (requestType === requestTypes.SERVICE_SUB_SERVICE_ACCESS) {
+        await updateUserServSubServRequest(request.id, updatedRequest);
+      }
+    }
+  }
+  logger.info(
+    `Returning [${remainingOutstandingRequests.length}] outstanding requests that all have at least 1 active approver`,
+  );
+  return remainingOutstandingRequests;
+};
+
+/**
+ *
+ * @param {Array} outstandingRequests
+ * @param {string} requestType
  * @param {Map} orgIdsByRequestCount
  * @param {moment.Moment} dateNow
  * @param {number} numberOfDaysUntilOverdue
@@ -130,19 +195,36 @@ const overdueAllRequestsTypes = async () => {
 
   // get all outstanding requests
   logger.info("Getting organisation request data with status of 0");
-  const allOutstandingOrgRequests = await listRequests(
+  let allOutstandingOrgRequests = await listRequests(
     500,
     [0],
     requestTypes.ORGANISATION_ACCESS,
   );
 
   logger.info("Getting service and sub-service request data with status of 0");
-  const allOutstandingServSubServRequests = await listRequests(
+  let allOutstandingServSubServRequests = await listRequests(
     500,
     [0],
     requestTypes.SERVICE_SUB_SERVICE_ACCESS,
   );
   const orgIdsByRequestCount = new Map();
+
+  logger.info(
+    "Updating outstanding org requests to status 3 if organisation has no active approvers",
+  );
+  allOutstandingOrgRequests = await updateRequestsWhereOrgHasNoActiveApprovers(
+    allOutstandingOrgRequests,
+    requestTypes.ORGANISATION_ACCESS,
+  );
+
+  logger.info(
+    "Updating outstanding servie requests to status 3 if organisation has no active approvers",
+  );
+  allOutstandingServSubServRequests =
+    await updateRequestsWhereOrgHasNoActiveApprovers(
+      allOutstandingServSubServRequests,
+      requestTypes.SERVICE_SUB_SERVICE_ACCESS,
+    );
 
   logger.info(
     "Updating overdue org requests to status 2 and nearly overdue ones into a list to send reminders",

--- a/test/appTests/overdueAllRequestsTypes/overdueRequests.test.js
+++ b/test/appTests/overdueAllRequestsTypes/overdueRequests.test.js
@@ -9,6 +9,7 @@ jest.mock("./../../../src/infrastructure/logger", () => {
     debug: jest.fn(),
   };
 });
+jest.mock("login.dfe.jobs-client");
 jest.mock("../../../src/infrastructure/directories");
 jest.mock("./../../../src/app/organisations/data/organisationsStorage", () => {
   const getApproversForOrg = jest.fn();
@@ -34,59 +35,45 @@ const {
   pagedListOfServSubServRequests,
   getApproversForOrg,
   updateUserOrgRequest,
+  updateUserServSubServRequest,
 } = require("./../../../src/app/organisations/data/organisationsStorage");
 const { getUsersByIds } = require("../../../src/infrastructure/directories");
+const { NotificationClient } = require("login.dfe.jobs-client");
 const moment = require("moment");
 
 const overdueAllRequestsTypes = require("../../../src/app/overdueAllRequestsTypes/overdueRequests");
 const dateNow = moment();
 
-describe("when calling the overdueAllRequestsTypes function", () => {
+describe("when calling the overdueAllRequestsTypes function on organisation requests", () => {
   beforeEach(() => {
-    getUsersByIds.mockReset().mockReturnValue([{}]);
+    NotificationClient.mockReset();
+    getUsersByIds.mockReset().mockReturnValue([
+      {
+        sub: "089B72CD-7C80-4348-9C2A-395213B7ECAD",
+        given_name: "Eoin",
+        family_name: "Corr",
+        email: "eoincorr021+17@gmail.com",
+        job_title: null,
+        status: 1,
+        phone_number: null,
+        last_login: "2020-02-19T08:53:00.000Z",
+        prev_login: null,
+        isEntra: false,
+        entraOid: null,
+        entraLinked: null,
+        isInternalUser: false,
+        entraDeferUntil: null,
+      },
+    ]);
 
     getApproversForOrg
       .mockReset()
       .mockReturnValue(["089B72CD-7C80-4348-9C2A-395213B7ECAD"]);
 
-    //approversDetails
-    // [
-    //   {
-    //     sub: '089B72CD-7C80-4348-9C2A-395213B7ECAD',
-    //     given_name: 'Eoin',
-    //     family_name: 'Corr',
-    //     email: 'eoincorr021+17@gmail.com',
-    //     job_title: null,
-    //     status: 0,
-    //     phone_number: null,
-    //     last_login: '2020-02-19T08:53:00.000Z',
-    //     prev_login: null,
-    //     isEntra: false,
-    //     entraOid: null,
-    //     entraLinked: null,
-    //     isInternalUser: false,
-    //     entraDeferUntil: null
-    //   },
-    //   {
-    //     sub: '727A9392-63A4-4B91-BAAF-6D9CA675DFE0',
-    //     given_name: 'Test2505',
-    //     family_name: 'user6',
-    //     email: 'Test2505user6@yopmail.com',
-    //     job_title: null,
-    //     status: 1,
-    //     phone_number: null,
-    //     last_login: '2021-06-14T13:49:00.000Z',
-    //     prev_login: null,
-    //     isEntra: false,
-    //     entraOid: null,
-    //     entraLinked: null,
-    //     isInternalUser: false,
-    //     entraDeferUntil: null
-    //   }]
     updateUserOrgRequest.mockReset();
+    updateUserServSubServRequest.mockReset();
 
-    pagedListOfRequests.mockReset();
-    pagedListOfRequests.mockReturnValue({
+    pagedListOfRequests.mockReset().mockReturnValue({
       requests: [
         {
           id: "request-1",
@@ -105,8 +92,7 @@ describe("when calling the overdueAllRequestsTypes function", () => {
       totalNumberOfRecords: 30,
     });
 
-    pagedListOfServSubServRequests.mockReset();
-    pagedListOfServSubServRequests.mockReturnValue({
+    pagedListOfServSubServRequests.mockReset().mockReturnValue({
       requests: [],
       page: 1,
       totalNumberOfPages: 1,
@@ -129,21 +115,24 @@ describe("when calling the overdueAllRequestsTypes function", () => {
     }
   });
 
-  it("should set the request to status 3 if the org has no approvers", async () => {
-    getApproversForOrg.mockReset();
-    getApproversForOrg.mockReturnValue([]);
+  it("should not update the status of the org request if it's in date and has approvers", async () => {
+    await overdueAllRequestsTypes();
+
+    expect(updateUserOrgRequest).toHaveBeenCalledTimes(0);
+  });
+
+  it("should set the org request to status 3 if the org has no approvers", async () => {
+    getApproversForOrg.mockReset().mockReturnValue([]);
 
     await overdueAllRequestsTypes();
 
     expect(updateUserOrgRequest).toHaveBeenCalledTimes(1);
   });
 
-  it("should set the request to status 3 if the org has approvers but they're all deactivated", async () => {
-    getApproversForOrg.mockReset();
-    getApproversForOrg.mockReturnValue([
-      "089B72CD-7C80-4348-9C2A-395213B7ECAD",
-    ]);
-
+  it("should set the org request to status 3 if the org has approvers but they're all deactivated", async () => {
+    getApproversForOrg
+      .mockReset()
+      .mockReturnValue(["089B72CD-7C80-4348-9C2A-395213B7ECAD"]);
     getUsersByIds.mockReset().mockReturnValue([
       {
         sub: "089B72CD-7C80-4348-9C2A-395213B7ECAD",
@@ -168,12 +157,37 @@ describe("when calling the overdueAllRequestsTypes function", () => {
     expect(updateUserOrgRequest).toHaveBeenCalledTimes(1);
   });
 
-  it("should set the request to status 3 if the org has approvers but they're all deactivated", async () => {
-    getApproversForOrg.mockReset();
-    getApproversForOrg.mockReturnValue([
-      "089B72CD-7C80-4348-9C2A-395213B7ECAD",
-    ]);
+  it("should update the org request to status 2 when overdue", async () => {
+    pagedListOfRequests.mockReset().mockReturnValue({
+      requests: [
+        {
+          id: "request-1",
+          org_id: "org-1",
+          org_name: "org name",
+          user_id: "user-1",
+          created_date: moment().subtract(5, "days"),
+          status: {
+            id: 0,
+            name: "Pending",
+          },
+        },
+      ],
+      page: 1,
+      totalNumberOfPages: 1,
+      totalNumberOfRecords: 30,
+    });
+    await overdueAllRequestsTypes();
 
+    expect(updateUserOrgRequest).toHaveBeenCalledTimes(1);
+    expect(updateUserOrgRequest).toHaveBeenCalledWith("request-1", {
+      status: 2,
+    });
+  });
+});
+
+describe("when calling the overdueAllRequestsTypes function on service requests", () => {
+  beforeEach(() => {
+    NotificationClient.mockReset();
     getUsersByIds.mockReset().mockReturnValue([
       {
         sub: "089B72CD-7C80-4348-9C2A-395213B7ECAD",
@@ -193,8 +207,122 @@ describe("when calling the overdueAllRequestsTypes function", () => {
       },
     ]);
 
+    getApproversForOrg
+      .mockReset()
+      .mockReturnValue(["089B72CD-7C80-4348-9C2A-395213B7ECAD"]);
+
+    updateUserOrgRequest.mockReset();
+    updateUserServSubServRequest.mockReset();
+
+    pagedListOfServSubServRequests.mockReset().mockReturnValue({
+      requests: [
+        {
+          id: "request-1",
+          org_id: "org-1",
+          org_name: "org name",
+          user_id: "user-1",
+          created_date: dateNow,
+          status: {
+            id: 0,
+            name: "Pending",
+          },
+        },
+      ],
+      page: 1,
+      totalNumberOfPages: 1,
+      totalNumberOfRecords: 30,
+    });
+
+    pagedListOfRequests.mockReset().mockReturnValue({
+      requests: [],
+      page: 1,
+      totalNumberOfPages: 1,
+      totalNumberOfRecords: 0,
+    });
+  });
+
+  it("raises an exception if an exception is raised on any api call", async () => {
+    pagedListOfRequests.mockReset().mockImplementation(() => {
+      const error = new Error("Client Error");
+      error.statusCode = 400;
+      throw error;
+    });
+
+    try {
+      await overdueAllRequestsTypes();
+    } catch (e) {
+      expect(e.statusCode).toEqual(400);
+      expect(e.message).toEqual("Client Error");
+    }
+  });
+
+  it("should not update the status of the service request if it's in date and has approvers", async () => {
     await overdueAllRequestsTypes();
 
-    expect(updateUserOrgRequest).toHaveBeenCalledTimes(0);
+    expect(updateUserServSubServRequest).toHaveBeenCalledTimes(0);
+  });
+
+  it("should set the service request to status 3 if the org has no approvers", async () => {
+    getApproversForOrg.mockReset().mockReturnValue([]);
+    getUsersByIds.mockReset().mockReturnValue([]);
+
+    await overdueAllRequestsTypes();
+
+    expect(getUsersByIds).toHaveBeenCalledTimes(0);
+    expect(updateUserServSubServRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("should set the service request to status 3 if the org has approvers but they're all deactivated", async () => {
+    getUsersByIds.mockReset().mockReturnValue([
+      {
+        sub: "089B72CD-7C80-4348-9C2A-395213B7ECAD",
+        given_name: "Eoin",
+        family_name: "Corr",
+        email: "eoincorr021+17@gmail.com",
+        job_title: null,
+        status: 0,
+        phone_number: null,
+        last_login: "2020-02-19T08:53:00.000Z",
+        prev_login: null,
+        isEntra: false,
+        entraOid: null,
+        entraLinked: null,
+        isInternalUser: false,
+        entraDeferUntil: null,
+      },
+    ]);
+
+    await overdueAllRequestsTypes();
+
+    expect(getUsersByIds).toHaveBeenCalledTimes(1);
+    expect(updateUserServSubServRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("should update the service request to status 2 when overdue and give an actioned reason", async () => {
+    pagedListOfServSubServRequests.mockReset().mockReturnValue({
+      requests: [
+        {
+          id: "request-1",
+          org_id: "org-1",
+          org_name: "org name",
+          user_id: "user-1",
+          created_date: moment().subtract(5, "days"),
+          status: {
+            id: 0,
+            name: "Pending",
+          },
+        },
+      ],
+      page: 1,
+      totalNumberOfPages: 1,
+      totalNumberOfRecords: 30,
+    });
+    await overdueAllRequestsTypes();
+
+    expect(updateUserServSubServRequest).toHaveBeenCalledTimes(1);
+    expect(updateUserServSubServRequest).toHaveBeenCalledWith("request-1", {
+      actioned_reason: "Overdue",
+      status: 2,
+    });
   });
 });

--- a/test/appTests/overdueAllRequestsTypes/overdueRequests.test.js
+++ b/test/appTests/overdueAllRequestsTypes/overdueRequests.test.js
@@ -40,6 +40,61 @@ describe("when calling the overdueAllRequestsTypes function", () => {
     getUsersByIds.mockReset();
     getUsersByIds.mockReturnValue([{}]);
 
+    // request
+    // {
+    //   id: '558910BF-172D-4405-9276-4A3650B9E2B3',
+    //   org_id: 'E41782FC-1A18-4E30-A315-CCC624AD7516',
+    //   org_name: 'Abbeywood Community School',
+    //   user_id: '6BEA40AE-947D-4767-9A97-C52FCED78B33',
+    //   created_date: 2025-03-11T16:33:16.492Z,
+    //   status: { id: 0, name: 'Pending' },
+    //   reason: 'Another reason'
+    // }
+
+    // approversForOrg
+    // [
+    //   '089B72CD-7C80-4348-9C2A-395213B7ECAD',
+    //   '727A9392-63A4-4B91-BAAF-6D9CA675DFE0',
+    //   'CA518CBE-83E0-4271-8327-7C09D0A641C7',
+    //   '3BDAD46B-D9AD-44B6-9D27-B5FF14CD945E',
+    //   '5A5C8CDE-1535-48B5-A5DB-D75360DFBB63'
+    // ]
+
+    //approversDetails
+    // [
+    //   {
+    //     sub: '089B72CD-7C80-4348-9C2A-395213B7ECAD',
+    //     given_name: 'Eoin',
+    //     family_name: 'Corr',
+    //     email: 'eoincorr021+17@gmail.com',
+    //     job_title: null,
+    //     status: 0,
+    //     phone_number: null,
+    //     last_login: '2020-02-19T08:53:00.000Z',
+    //     prev_login: null,
+    //     isEntra: false,
+    //     entraOid: null,
+    //     entraLinked: null,
+    //     isInternalUser: false,
+    //     entraDeferUntil: null
+    //   },
+    //   {
+    //     sub: '727A9392-63A4-4B91-BAAF-6D9CA675DFE0',
+    //     given_name: 'Test2505',
+    //     family_name: 'user6',
+    //     email: 'Test2505user6@yopmail.com',
+    //     job_title: null,
+    //     status: 1,
+    //     phone_number: null,
+    //     last_login: '2021-06-14T13:49:00.000Z',
+    //     prev_login: null,
+    //     isEntra: false,
+    //     entraOid: null,
+    //     entraLinked: null,
+    //     isInternalUser: false,
+    //     entraDeferUntil: null
+    //   }]
+
     pagedListOfRequests.mockReset();
     pagedListOfRequests.mockReturnValue({
       requests: [


### PR DESCRIPTION
This PR has 2 parts to it:
First, When an org request is created, it will be set to status 3 if either 
- The organisation has no approvers
-  The organisation has approvers, but they've all been deactivated. (Previously it would be set to status 0 in this case)

Second, the organisation worker has been updated to also do this check.  Previously a request would stay status 0 until it was overdue, then become status 2.
Now, every day when it runs, it goes through all the pending requests and checks to see if it needs to be set to status 3 if either the org now has no approvers, or the last approver was deactivated.  The latter is going to be the much more common case, but it is technically possible that the link that makes a user an approver could be broken so we'll check for it just in-case.

Small note just in case it becomes an issue down the line.  For the `getApproversForOrg` and `getUsersDetails` calls, I chose not to do any sort of caching of the results as it would complicate the implementation and take longer to implement for only a potentially small speed improvement over a fairly small number of operations (the number of unapproved org/service requests
will likely be in the 10s, maybe 100s at a push for any given 5 day period).  If speed/reliability becomes an issue because the directories API is getting hammered for the same information then a simple dictionary to service as a cache for approvers (keyed by `orgId`) and one for user details (keyed by `user_id`) would easily solve the issue.