### PR TITLE
[DSI-7507, DSI-7508] Update various dfe packages 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "login.dfe.express-error-handling": "^3.0.3",
         "login.dfe.healthcheck": "^3.0.3",
         "login.dfe.jobs-client": "^6.1.2",
-        "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.1",
+        "login.dfe.jwt-strategies": "^4.1.2",
         "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
         "memory-streams": "^0.1.3",
         "moment": "^2.30.1",
@@ -7028,11 +7028,12 @@
       }
     },
     "node_modules/login.dfe.jwt-strategies": {
-      "version": "4.1.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jwt-strategies.git#e73c81f47d8352b2609c2eeab691e5c68c8f6727",
+      "version": "4.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.jwt-strategies/-/login.dfe.jwt-strategies-4.1.2.tgz",
+      "integrity": "sha1-7hfPQhQ2LXI7JTonPI9E7jX53vM=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-node": "^2.6.4"
+        "@azure/msal-node": "^2.16.2"
       }
     },
     "node_modules/login.dfe.winston-appinsights": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "login.dfe.express-error-handling": "^3.0.3",
     "login.dfe.healthcheck": "^3.0.3",
     "login.dfe.jobs-client": "^6.1.2",
-    "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.1",
+    "login.dfe.jwt-strategies": "^4.1.2",
     "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
     "memory-streams": "^0.1.3",
     "moment": "^2.30.1",


### PR DESCRIPTION
## Summary
Jira ticket: 
- https://dfe-secureaccess.atlassian.net/browse/DSI-7507
- https://dfe-secureaccess.atlassian.net/browse/DSI-7508

### Changes

- Update `login.dfe.jobs-client` to use version package ^6.1.2
- Update `login.dfe.jwt-strategies` to use version package ^4.1.2


### Related PRs:
- https://github.com/DFE-Digital/login.dfe.jobs-client/pull/5
- https://github.com/DFE-Digital/login.dfe.jwt-strategies/pull/33