### PR TITLE
[DSI-8381] Remove login.dfe.audit.transporter package in login.dfe.organisations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,8 @@
         "xml2js": "^0.6.2"
       },
       "devDependencies": {
-        "@eslint/js": "^9.39.1",
-        "eslint": "^9.39.1",
+        "@eslint/js": "^9.39.2",
+        "eslint": "^9.39.2",
         "eslint-formatter-junit": "^8.40.0",
         "eslint-plugin-jest": "^28.14.0",
         "globals": "^15.13.0",
@@ -1189,9 +1189,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-9.39.1.tgz",
-      "integrity": "sha1-DdWcOp9A4/GIKXXDIUcJaSQ+AWQ=",
+      "version": "9.39.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha1-LUuOxMPqE8GzdI4Ml+zXZr3YBZk=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4000,9 +4000,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-9.39.1.tgz",
-      "integrity": "sha1-vov3xt533MQlK1qNyzHC7/90puU=",
+      "version": "9.39.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-9.39.2.tgz",
+      "integrity": "sha1-y2Dm0WqyNMD4Npo/58yHln+vS2w=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4012,7 +4012,7 @@
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.1",
+        "@eslint/js": "9.39.2",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8281,9 +8281,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha1-xj+kBoDSxclBQSoOiZyJr2DAqTA=",
+      "version": "6.14.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha1-pB2FudOQLzHSeGF5BQYpSIGHEVk=",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "lodash": "^4.17.21",
         "login.dfe.api-client": "^1.0.58",
         "login.dfe.api.auth": "^2.3.4",
-        "login.dfe.audit.transporter": "^4.0.3",
         "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
         "login.dfe.config.schema.common": "^2.1.8",
         "login.dfe.express-error-handling": "^3.0.5",
@@ -75,27 +74,6 @@
       "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-amqp": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-amqp/-/core-amqp-4.3.5.tgz",
-      "integrity": "sha1-6KpIRBsB3XCTVTB6Q4kOLMtAnWY=",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.7.2",
-        "@azure/core-util": "^1.9.0",
-        "@azure/logger": "^1.1.2",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "rhea": "^3.0.0",
-        "rhea-promise": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -246,19 +224,6 @@
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-xml": {
-      "version": "1.4.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-xml/-/core-xml-1.4.4.tgz",
-      "integrity": "sha1-qGVnUZQ79JJ2L3WNFH0z382TPZ4=",
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-parser": "^4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -465,47 +430,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/service-bus": {
-      "version": "7.9.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/service-bus/-/service-bus-7.9.5.tgz",
-      "integrity": "sha1-rVpvPK+eMmnF6DjXsV7NAw4tjTM=",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-amqp": "^4.1.1",
-        "@azure/core-auth": "^1.3.0",
-        "@azure/core-client": "^1.0.0",
-        "@azure/core-paging": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.1.0",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.1.1",
-        "@azure/core-xml": "^1.0.0",
-        "@azure/logger": "^1.0.0",
-        "@types/is-buffer": "^2.0.0",
-        "buffer": "^6.0.0",
-        "is-buffer": "^2.0.3",
-        "jssha": "^3.1.0",
-        "long": "^5.2.0",
-        "process": "^0.11.10",
-        "rhea-promise": "^3.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/service-bus/node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2112,15 +2036,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
       "integrity": "sha1-Kga8D2iiCrN7PjaqI4vmq99J6LQ=",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/is-buffer": {
-      "version": "2.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/is-buffer/-/is-buffer-2.0.2.tgz",
-      "integrity": "sha1-Pc2OIefWwtMS0Ln2zyO7bKHvn3Y=",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -4489,24 +4404,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha1-xU1rNaoPI9wepgtsiENAwAbcbvs=",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^1.1.1"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.19.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fastq/-/fastq-1.19.0.tgz",
@@ -5267,29 +5164,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha1-68JS5ADSL/jXf6CYiIIaJKZYwZE=",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/is-core-module": {
@@ -6267,15 +6141,6 @@
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
-    "node_modules/jssha": {
-      "version": "3.3.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jssha/-/jssha-3.3.1.tgz",
-      "integrity": "sha1-xbf8f7mqdFRhkjuH3w4kfdWcfqg=",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/jwa": {
       "version": "1.4.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jwa/-/jwa-1.4.2.tgz",
@@ -6874,33 +6739,6 @@
         "passport": "^0.6.0",
         "passport-azure-ad": "^4.3.5"
       }
-    },
-    "node_modules/login.dfe.audit.transporter": {
-      "version": "4.0.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.audit.transporter/-/login.dfe.audit.transporter-4.0.3.tgz",
-      "integrity": "sha1-tp2hElSWX3MIM3Hj1cDO9cEE9ds=",
-      "license": "ISC",
-      "dependencies": {
-        "@azure/service-bus": "^7.9.5",
-        "@types/node": "^20.17.28",
-        "winston": "^3.16.0",
-        "winston-transport": "^4.9.0"
-      }
-    },
-    "node_modules/login.dfe.audit.transporter/node_modules/@types/node": {
-      "version": "20.17.30",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-20.17.30.tgz",
-      "integrity": "sha1-HZP2VtO4advve3llaKxFdga6WNA=",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/login.dfe.audit.transporter/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha1-NREcnRQ3q4OnzcCrri8m2I7aCgI=",
-      "license": "MIT"
     },
     "node_modules/login.dfe.audit.winston-sequelize-transport": {
       "version": "3.2.6",
@@ -8608,72 +8446,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rhea": {
-      "version": "3.0.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rhea/-/rhea-3.0.3.tgz",
-      "integrity": "sha1-OP8US3+MqYKmdxiqH15nvZMHVnk=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.3.3"
-      }
-    },
-    "node_modules/rhea-promise": {
-      "version": "3.0.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rhea-promise/-/rhea-promise-3.0.3.tgz",
-      "integrity": "sha1-/GjjkBlELFM4o5mbXj4ogG8/ENI=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.0.0",
-        "rhea": "^3.0.0",
-        "tslib": "^2.6.0"
-      }
-    },
-    "node_modules/rhea-promise/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rhea-promise/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
-      "license": "MIT"
-    },
-    "node_modules/rhea/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rhea/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
-      "license": "MIT"
-    },
     "node_modules/rimraf": {
       "version": "2.4.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rimraf/-/rimraf-2.4.5.tgz",
@@ -9407,18 +9179,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/strnum": {
-      "version": "1.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strnum/-/strnum-1.1.1.tgz",
-      "integrity": "sha1-azEpNAVFlN1hG9GNm8zlBTp8qu4=",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.1",
-    "eslint": "^9.39.1",
+    "@eslint/js": "^9.39.2",
+    "eslint": "^9.39.2",
     "eslint-formatter-junit": "^8.40.0",
     "eslint-plugin-jest": "^28.14.0",
     "globals": "^15.13.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "lodash": "^4.17.21",
     "login.dfe.api-client": "^1.0.58",
     "login.dfe.api.auth": "^2.3.4",
-    "login.dfe.audit.transporter": "^4.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",
     "login.dfe.express-error-handling": "^3.0.5",


### PR DESCRIPTION
## Summary
**Jira ticket:** https://dfe-secureaccess.atlassian.net/browse/DSI-8381
## Changes 
-fix vulnerable packages
-update various outdated packages
-remove unused `login.dfe.audit.transporter` package 

## Related PRs:

- [https://github.com.mcas.ms/DFE-Digital/login.dfe.audit-transporter/pull/34/changes](https://github.com/DFE-Digital/login.dfe.audit-transporter/pull/34/changes)
- https://github.com.mcas.ms/DFE-Digital/login.dfe.devops/pull/298
- https://github.com.mcas.ms/DFE-Digital/login.dfe.oidc/pull/299
- https://github.com.mcas.ms/DFE-Digital/login.dfe.directories/pull/378
- https://github.com/DFE-Digital/login.dfe.interactions/pull/652
- https://github.com.mcas.ms/DFE-Digital/login.dfe.help/pull/315