### PR TITLE
Rewrite getUsersOfServiceByUserIds to use raw SQL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -539,6 +539,7 @@
       "integrity": "sha1-cYOFQqSx5J3+01PXrLxuuJ9KdvI=",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1866,6 +1867,71 @@
         "darwin"
       ]
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha1-M2d6J1IEiYrYrL9ic0/E3AtqSFU=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha1-lPsFQ7ouKHZsP8Q5yrvgRArnAVk=",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha1-Ge33zcLnBj7jKEA8HYlaht0o9Ls=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha1-SgYJq1/kTQfJxgoR5EhNPDi71uM=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha1-CqVQLVR7V6v8SsSS3mjiAG5BckI=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1908,6 +1974,7 @@
       "version": "1.9.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha1-0D66aCc9wPdQnio9XLoh6uEDef4=",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2412,6 +2479,7 @@
       "version": "8.15.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha1-o2CJi8QV7arEbIJB9jg5dbkwuBY=",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2942,6 +3010,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -3803,6 +3872,7 @@
       "version": "1.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
       "integrity": "sha1-RLYJct6e4FXBYhZTWw6ds/ag79A=",
+      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       }
@@ -5556,6 +5626,7 @@
       "integrity": "sha1-mUZ2/CQXfwiPHF43N/VpcgT/JhM=",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7905,6 +7976,7 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg/-/pg-8.16.3.tgz",
       "integrity": "sha1-FgdB0LRP32RoDkU3SwbWMuhsmf0=",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",

--- a/src/infrastructure/repository/index.js
+++ b/src/infrastructure/repository/index.js
@@ -209,4 +209,6 @@ buildDataModel(dataModel, db, [
   userServiceRequestsModel,
 ]);
 
+dataModel.sequelize = db;
+
 module.exports = dataModel;

--- a/test/appTests/servicesTests/data/mockServicesRepository.js
+++ b/test/appTests/servicesTests/data/mockServicesRepository.js
@@ -26,9 +26,13 @@ const mockRepository = () => {
     users: mockTable(),
     userServices: mockTable(),
     organisations: mockTable(),
+    sequelize: {
+      query: jest.fn(),
+    },
 
     mockResetAll: function () {
       this.connection.query.mockReset();
+      this.sequelize.query.mockReset();
       this.users.mockResetAll();
       this.userServices.mockResetAll();
       this.organisations.mockResetAll();


### PR DESCRIPTION
Refactor the `getUsersOfServiceByUserIds` function to utilize raw SQL for improved performance and reliability. Update tests to align with the new implementation, fix linter errors, and resolve issues with Sequelize query exports. Add temporary logging for diagnostics and tidy up existing logging.