### PR TITLE
[NSA-9733] Add UKRLP Providers (054) to organisationCategory lookup

### DIFF
--- a/src/infrastructure/repository/index.js
+++ b/src/infrastructure/repository/index.js
@@ -76,6 +76,7 @@ const defineStatic = (model) => {
     { id: "051", name: "PIMS Training Providers" },
     { id: "052", name: "Billing Authority" },
     { id: "053", name: "Youth Custody Service" },
+    { id: "054", name: "UKRLP Providers" },
   ];
 
   model.establishmentTypes = [


### PR DESCRIPTION
Category 054 was missing from the static organisationCategory list, causing the organisations API to return category: undefined for UKRLP orgs. This prevented the policy engine condition organisation.category.id = '054' from ever matching.