### PR TITLE
NSA-9846: accept filteruserid query param and apply user_id WHERE clause in pagedListOfAllRequestTypes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "fs": "^0.0.2",
         "helmet": "^7.2.0",
         "lodash": "^4.17.21",
-        "login.dfe.api-client": "^1.0.64",
+        "login.dfe.api-client": "^1.0.71",
         "login.dfe.api.auth": "^2.3.4",
         "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
         "login.dfe.config.schema.common": "^2.1.8",
@@ -6775,9 +6775,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api-client": {
-      "version": "1.0.69",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.69.tgz",
-      "integrity": "sha1-AHNFlmxl5DgYgGFnNm4zVHdbItA=",
+      "version": "1.0.71",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.71.tgz",
+      "integrity": "sha1-Gt4OSza42CMGykX1NejhKlUoeDM=",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",
         "applicationinsights": "^2.9.6",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fs": "^0.0.2",
     "helmet": "^7.2.0",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.69",
+    "login.dfe.api-client": "^1.0.71",
     "login.dfe.api.auth": "^2.3.4",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/src/app/organisations/data/organisationsStorage.js
+++ b/src/app/organisations/data/organisationsStorage.js
@@ -2079,6 +2079,7 @@ const pagedListOfAllRequestTypes = async (
   pageSize = 25,
   filterStates = undefined,
   filterTypes = undefined,
+  filterUserId = undefined,
 ) => {
   const includeOrg =
     !filterTypes ||
@@ -2106,6 +2107,11 @@ const pagedListOfAllRequestTypes = async (
   if (filterStates && filterStates.length > 0) {
     orgQuery.where.status = { [Op.in]: filterStates };
     servQuery.where.status = { [Op.in]: filterStates };
+  }
+
+  if (filterUserId) {
+    orgQuery.where.user_id = filterUserId;
+    servQuery.where.user_id = filterUserId;
   }
 
   let orgResults = [];

--- a/src/app/organisations/listRequests.js
+++ b/src/app/organisations/listRequests.js
@@ -29,8 +29,9 @@ const listRequests = async (req, res) => {
   const pageNumber = getPageNumber(req);
   const filterStates = fixMultiSelect(req.query.filterstatus);
   const filterTypes = fixMultiSelect(req.query.filtertype);
+  const filterUserId = req.query.filteruserid || undefined;
 
-  const page = await pagedListOfAllRequestTypes(pageNumber, pageSize, filterStates, filterTypes);
+  const page = await pagedListOfAllRequestTypes(pageNumber, pageSize, filterStates, filterTypes, filterUserId);
 
   return res.contentType("json").send({
     requests: page.requests,

--- a/src/app/organisations/listRequests.js
+++ b/src/app/organisations/listRequests.js
@@ -29,6 +29,7 @@ const listRequests = async (req, res) => {
   const pageNumber = getPageNumber(req);
   const filterStates = fixMultiSelect(req.query.filterstatus);
   const filterTypes = fixMultiSelect(req.query.filtertype);
+  // || undefined coerces an explicit empty string (?filteruserid=) to undefined so the storage layer treats it as absent
   const filterUserId = req.query.filteruserid || undefined;
 
   const page = await pagedListOfAllRequestTypes(pageNumber, pageSize, filterStates, filterTypes, filterUserId);

--- a/test/appTests/organisationsTests/data/organisationStorage.pagedListOfAllRequestTypes.test.js
+++ b/test/appTests/organisationsTests/data/organisationStorage.pagedListOfAllRequestTypes.test.js
@@ -1,0 +1,59 @@
+jest.mock("./../../../../src/infrastructure/repository", () => ({
+  userOrganisationRequests: { findAll: jest.fn() },
+  userServiceRequests: { findAll: jest.fn() },
+  organisationRequestStatus: [],
+  serviceRequestStatus: [],
+  serviceRequestsTypes: [],
+}));
+jest.mock("./../../../../src/infrastructure/logger");
+
+const {
+  userOrganisationRequests,
+  userServiceRequests,
+} = require("./../../../../src/infrastructure/repository");
+const {
+  pagedListOfAllRequestTypes,
+} = require("./../../../../src/app/organisations/data/organisationsStorage");
+
+describe("pagedListOfAllRequestTypes - filterUserId", () => {
+  beforeEach(() => {
+    userOrganisationRequests.findAll.mockReset().mockResolvedValue([]);
+    userServiceRequests.findAll.mockReset().mockResolvedValue([]);
+  });
+
+  it("does not add user_id to org query when filterUserId is not provided", async () => {
+    await pagedListOfAllRequestTypes(1, 25, undefined, undefined, undefined);
+
+    const orgQuery = userOrganisationRequests.findAll.mock.calls[0][0];
+    expect(orgQuery.where).not.toHaveProperty("user_id");
+  });
+
+  it("adds user_id WHERE clause to org query when filterUserId is provided", async () => {
+    await pagedListOfAllRequestTypes(1, 25, undefined, undefined, "user-abc-123");
+
+    const orgQuery = userOrganisationRequests.findAll.mock.calls[0][0];
+    expect(orgQuery.where.user_id).toBe("user-abc-123");
+  });
+
+  it("adds user_id WHERE clause to service query when filterUserId is provided", async () => {
+    await pagedListOfAllRequestTypes(1, 25, undefined, ["service"], "user-abc-123");
+
+    const servQuery = userServiceRequests.findAll.mock.calls[0][0];
+    expect(servQuery.where.user_id).toBe("user-abc-123");
+  });
+
+  it("adds user_id WHERE clause to service query when filterTypes is undefined", async () => {
+    await pagedListOfAllRequestTypes(1, 25, undefined, undefined, "user-abc-123");
+
+    const servQuery = userServiceRequests.findAll.mock.calls[0][0];
+    expect(servQuery.where.user_id).toBe("user-abc-123");
+  });
+
+  it("combines user_id filter with status filter on org query", async () => {
+    await pagedListOfAllRequestTypes(1, 25, ["0"], undefined, "user-abc-123");
+
+    const orgQuery = userOrganisationRequests.findAll.mock.calls[0][0];
+    expect(orgQuery.where.user_id).toBe("user-abc-123");
+    expect(orgQuery.where).toHaveProperty("status");
+  });
+});

--- a/test/appTests/organisationsTests/data/organisationStorage.pagedListOfAllRequestTypes.test.js
+++ b/test/appTests/organisationsTests/data/organisationStorage.pagedListOfAllRequestTypes.test.js
@@ -29,21 +29,39 @@ describe("pagedListOfAllRequestTypes - filterUserId", () => {
   });
 
   it("adds user_id WHERE clause to org query when filterUserId is provided", async () => {
-    await pagedListOfAllRequestTypes(1, 25, undefined, undefined, "user-abc-123");
+    await pagedListOfAllRequestTypes(
+      1,
+      25,
+      undefined,
+      undefined,
+      "user-abc-123",
+    );
 
     const orgQuery = userOrganisationRequests.findAll.mock.calls[0][0];
     expect(orgQuery.where.user_id).toBe("user-abc-123");
   });
 
   it("adds user_id WHERE clause to service query when filterUserId is provided", async () => {
-    await pagedListOfAllRequestTypes(1, 25, undefined, ["service"], "user-abc-123");
+    await pagedListOfAllRequestTypes(
+      1,
+      25,
+      undefined,
+      ["service"],
+      "user-abc-123",
+    );
 
     const servQuery = userServiceRequests.findAll.mock.calls[0][0];
     expect(servQuery.where.user_id).toBe("user-abc-123");
   });
 
   it("adds user_id WHERE clause to service query when filterTypes is undefined", async () => {
-    await pagedListOfAllRequestTypes(1, 25, undefined, undefined, "user-abc-123");
+    await pagedListOfAllRequestTypes(
+      1,
+      25,
+      undefined,
+      undefined,
+      "user-abc-123",
+    );
 
     const servQuery = userServiceRequests.findAll.mock.calls[0][0];
     expect(servQuery.where.user_id).toBe("user-abc-123");
@@ -55,5 +73,42 @@ describe("pagedListOfAllRequestTypes - filterUserId", () => {
     const orgQuery = userOrganisationRequests.findAll.mock.calls[0][0];
     expect(orgQuery.where.user_id).toBe("user-abc-123");
     expect(orgQuery.where).toHaveProperty("status");
+  });
+
+  it("does not call userServiceRequests.findAll when filterTypes is organisation-only", async () => {
+    await pagedListOfAllRequestTypes(
+      1,
+      25,
+      undefined,
+      ["organisation"],
+      "user-abc-123",
+    );
+
+    expect(userOrganisationRequests.findAll).toHaveBeenCalledTimes(1);
+    expect(userServiceRequests.findAll).not.toHaveBeenCalled();
+    const orgQuery = userOrganisationRequests.findAll.mock.calls[0][0];
+    expect(orgQuery.where.user_id).toBe("user-abc-123");
+  });
+
+  it("does not call userOrganisationRequests.findAll when filterTypes is service-only", async () => {
+    await pagedListOfAllRequestTypes(
+      1,
+      25,
+      undefined,
+      ["service"],
+      "user-abc-123",
+    );
+
+    expect(userServiceRequests.findAll).toHaveBeenCalledTimes(1);
+    expect(userOrganisationRequests.findAll).not.toHaveBeenCalled();
+    const servQuery = userServiceRequests.findAll.mock.calls[0][0];
+    expect(servQuery.where.user_id).toBe("user-abc-123");
+  });
+
+  it("does not apply user_id filter when filterUserId is an empty string", async () => {
+    await pagedListOfAllRequestTypes(1, 25, undefined, undefined, "");
+
+    const orgQuery = userOrganisationRequests.findAll.mock.calls[0][0];
+    expect(orgQuery.where).not.toHaveProperty("user_id");
   });
 });

--- a/test/appTests/organisationsTests/listRequests.test.js
+++ b/test/appTests/organisationsTests/listRequests.test.js
@@ -118,4 +118,20 @@ describe("when getting requests that have been escalated to support", () => {
     expect(pagedListOfAllRequestTypes.mock.calls).toHaveLength(1);
     expect(pagedListOfAllRequestTypes.mock.calls[0][3]).toEqual(["service"]);
   });
+
+  it("then it should pass filterUserId to pagedListOfAllRequestTypes when filteruserid is in query", async () => {
+    req.query.filteruserid = "user-abc-123";
+
+    await getRequestsForSupport(req, res);
+
+    expect(pagedListOfAllRequestTypes.mock.calls).toHaveLength(1);
+    expect(pagedListOfAllRequestTypes.mock.calls[0][4]).toBe("user-abc-123");
+  });
+
+  it("then it should pass undefined as filterUserId when filteruserid is absent from query", async () => {
+    await getRequestsForSupport(req, res);
+
+    expect(pagedListOfAllRequestTypes.mock.calls).toHaveLength(1);
+    expect(pagedListOfAllRequestTypes.mock.calls[0][4]).toBeUndefined();
+  });
 });

--- a/test/appTests/organisationsTests/listRequests.test.js
+++ b/test/appTests/organisationsTests/listRequests.test.js
@@ -134,4 +134,13 @@ describe("when getting requests that have been escalated to support", () => {
     expect(pagedListOfAllRequestTypes.mock.calls).toHaveLength(1);
     expect(pagedListOfAllRequestTypes.mock.calls[0][4]).toBeUndefined();
   });
+
+  it("then it should pass undefined as filterUserId when filteruserid is an empty string", async () => {
+    req.query.filteruserid = "";
+
+    await getRequestsForSupport(req, res);
+
+    expect(pagedListOfAllRequestTypes.mock.calls).toHaveLength(1);
+    expect(pagedListOfAllRequestTypes.mock.calls[0][4]).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Adds user-level filtering to the organisation requests listing endpoint. When a `filteruserid` query parameter is supplied, the results are scoped to that user at the database level rather than in memory.

## Changes

**`src/app/organisations/listRequests.js`**
- Reads `filteruserid` from the incoming query string and maps it to `filterUserId`
- Passes it as the 5th argument to `pagedListOfAllRequestTypes`

**`src/app/organisations/data/organisationsStorage.js`**
- Added `filterUserId` as an optional 5th parameter to `pagedListOfAllRequestTypes`
- Applies `WHERE user_id = ?` to both `userOrganisationRequests` and `userServiceRequests` queries when the parameter is present
- Combines correctly with the existing `filterStates` WHERE clause

**Tests**
- New test file covering 5 cases: no filter applied when omitted; `user_id` applied to org query; `user_id` applied to service query with explicit filterTypes; `user_id` applied to service query when filterTypes is undefined; combined with status filter
- 2 additional test cases in `listRequests.test.js` verifying the param is extracted and forwarded correctly

## Linked ticket

NSA-9846
