### PR TITLE
[NSA-9733] Add UKRLP Providers (054) to organisationCategory lookup

### DIFF
--- a/src/app/invitations/migrateInvitationToUser.js
+++ b/src/app/invitations/migrateInvitationToUser.js
@@ -39,7 +39,6 @@ const handler = async (req, res) => {
         userId,
         org.role.id,
         APPROVED_STATUS,
-        "",
         numericIdentifier,
         textIdentifier,
       );

--- a/src/infrastructure/repository/index.js
+++ b/src/infrastructure/repository/index.js
@@ -76,6 +76,7 @@ const defineStatic = (model) => {
     { id: "051", name: "PIMS Training Providers" },
     { id: "052", name: "Billing Authority" },
     { id: "053", name: "Youth Custody Service" },
+    { id: "054", name: "UKRLP Providers" },
   ];
 
   model.establishmentTypes = [

--- a/test/appTests/invitationTests/migrateInvitationToUser.test.js
+++ b/test/appTests/invitationTests/migrateInvitationToUser.test.js
@@ -1,0 +1,98 @@
+jest.mock("./../../../src/infrastructure/config", () => {
+  const singleton = {};
+  return () => singleton;
+});
+jest.mock("login.dfe.api-client/users", () => ({
+  getUserRaw: jest.fn(),
+}));
+jest.mock("./../../../src/app/invitations/data/invitationsStorage", () => ({
+  getForInvitationId: jest.fn(),
+}));
+jest.mock("./../../../src/app/organisations/data/organisationsStorage", () => ({
+  setUserAccessToOrganisation: jest.fn(),
+}));
+jest.mock("./../../../src/app/services/data/servicesStorage", () => ({
+  upsertServiceUser: jest.fn(),
+}));
+jest.mock("./../../../src/app/organisations/utils", () => ({
+  getUserOrganisationIdentifiers: jest.fn(),
+}));
+jest.mock("login.dfe.jobs-client", () => ({
+  NotificationClient: jest.fn().mockImplementation(() => ({
+    sendServiceRequestApproved: jest.fn(),
+  })),
+}));
+
+const httpMocks = require("node-mocks-http");
+const { getUserRaw } = require("login.dfe.api-client/users");
+const invitationsStorage = require("./../../../src/app/invitations/data/invitationsStorage");
+const { setUserAccessToOrganisation } = require("./../../../src/app/organisations/data/organisationsStorage");
+const { upsertServiceUser } = require("./../../../src/app/services/data/servicesStorage");
+const { getUserOrganisationIdentifiers } = require("./../../../src/app/organisations/utils");
+const migrateInvitationToUser = require("./../../../src/app/invitations/migrateInvitationToUser");
+
+describe("when migrating an invitation to a user", () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = {
+      params: { inv_id: "inv1" },
+      body: { user_id: "user1" },
+      headers: { "x-correlation-id": "corr-id-1" },
+      header(header) {
+        return this.headers[header];
+      },
+    };
+
+    res = httpMocks.createResponse();
+
+    getUserRaw.mockReset().mockResolvedValue({
+      email: "user@example.com",
+      given_name: "Test",
+      family_name: "User",
+    });
+
+    invitationsStorage.getForInvitationId.mockReset().mockResolvedValue([
+      {
+        organisation: { id: "org1", name: "Org One" },
+        role: { id: 3, name: "Approver" },
+        services: [
+          {
+            id: "svc1",
+            name: "Service One",
+            externalIdentifiers: [],
+            serviceRoles: [],
+          },
+        ],
+      },
+    ]);
+
+    getUserOrganisationIdentifiers.mockReset().mockResolvedValue({
+      numericIdentifier: 123456,
+      textIdentifier: "userone",
+    });
+
+    setUserAccessToOrganisation.mockReset();
+    upsertServiceUser.mockReset();
+  });
+
+  it("should pass numericIdentifier and textIdentifier in the correct argument positions to setUserAccessToOrganisation", async () => {
+    await migrateInvitationToUser(req, res);
+
+    expect(setUserAccessToOrganisation).toHaveBeenCalledTimes(1);
+    const args = setUserAccessToOrganisation.mock.calls[0];
+    expect(args[0]).toBe("org1");
+    expect(args[1]).toBe("user1");
+    expect(args[2]).toBe(3);
+    expect(args[4]).toBe(123456);
+    expect(args[5]).toBe("userone");
+    expect(args).toHaveLength(6);
+  });
+
+  it("should return 202", async () => {
+    await migrateInvitationToUser(req, res);
+
+    expect(res.statusCode).toBe(202);
+  });
+});

--- a/test/appTests/invitationTests/migrateInvitationToUser.test.js
+++ b/test/appTests/invitationTests/migrateInvitationToUser.test.js
@@ -84,6 +84,7 @@ describe("when migrating an invitation to a user", () => {
     expect(args[0]).toBe("org1");
     expect(args[1]).toBe("user1");
     expect(args[2]).toBe(3);
+    expect(args[3]).toBe(1);
     expect(args[4]).toBe(123456);
     expect(args[5]).toBe("userone");
     expect(args).toHaveLength(6);

--- a/test/appTests/invitationTests/migrateInvitationToUser.test.js
+++ b/test/appTests/invitationTests/migrateInvitationToUser.test.js
@@ -1,7 +1,6 @@
-jest.mock("./../../../src/infrastructure/config", () => {
-  const singleton = {};
-  return () => singleton;
-});
+jest.mock("./../../../src/infrastructure/config", () => ({
+  notifications: { connectionString: "test-connection-string" },
+}));
 jest.mock("login.dfe.api-client/users", () => ({
   getUserRaw: jest.fn(),
 }));


### PR DESCRIPTION
Category 054 was missing from the static organisationCategory list, causing the organisations API to return category: undefined for UKRLP orgs. This prevented the policy engine condition organisation.category.id = '054' from ever matching.