### PR TITLE
feat(NSA-9950): add GET /organisations/collect-without-active-users endpoint

### DIFF
--- a/src/app/organisations/data/organisationsStorage.js
+++ b/src/app/organisations/data/organisationsStorage.js
@@ -549,10 +549,15 @@ const collectOrgsWithoutActiveUsersFrom = `
         -- rows for the whole query.
         SELECT 1
         FROM dbo.[user_services] us
-        JOIN dbo.[service] s ON s.id = us.service_id
+        JOIN dbo.[user] u ON u.sub = us.user_id
         WHERE us.organisation_id = o.id
-          AND s.id = :collectServiceId
+          AND us.service_id = :collectServiceId
+          -- Both statuses matter. Deactivating a user changes only the user
+          -- record, leaving their user_services row active, so checking the
+          -- access row alone would treat an organisation whose only Collect
+          -- users are deactivated as covered - the exact gap this reports on.
           AND us.status = 1
+          AND u.status = 1
       )`;
 
 const pagedListOfCollectOrgsWithoutActiveUsers = async (

--- a/src/app/organisations/data/organisationsStorage.js
+++ b/src/app/organisations/data/organisationsStorage.js
@@ -18,6 +18,7 @@ const {
   getNextNumericId,
   getNextLegacyId,
   userServiceRequests,
+  sequelize,
 } = require("./../../../infrastructure/repository");
 const Sequelize = require("sequelize");
 const { uniq, trim, orderBy } = require("lodash");
@@ -521,6 +522,86 @@ const pagedListOfCategory = async (
   const totalNumberOfPages = Math.ceil(totalNumberOfRecords / pageSize);
   return {
     organisations: orgs,
+    totalNumberOfPages,
+    totalNumberOfRecords,
+  };
+};
+
+// Organisations that Collect expects data from but which currently have nobody
+// able to submit it - no active Collect access in DSI at all. Includes
+// organisations that have never had Collect access, not only those that lost
+// it: the narrower "previously had access" query returns no rows in production,
+// and an organisation that was never set up cannot submit either.
+const collectOrgsWithoutActiveUsersFrom = `
+    FROM dbo.[organisation] o
+    WHERE o.Status = 1
+      -- Only organisation types with a statutory Collect reporting obligation,
+      -- confirmed with the data collections team: 001 = Establishment
+      -- (School Census / SLASC / EYC submitters), 002 = Local Authority
+      -- (SEN2 / S251 / CIN returns). Other active DSI categories - training
+      -- providers, software suppliers, government bodies - have no such
+      -- obligation and would otherwise swamp the report.
+      AND o.Category IN ('001', '002')
+      AND NOT EXISTS (
+        -- NOT EXISTS rather than NOT IN: user_services.organisation_id has no
+        -- NOT NULL constraint, and NOT IN against a subquery containing even
+        -- one NULL evaluates to UNKNOWN for every row, silently returning zero
+        -- rows for the whole query.
+        SELECT 1
+        FROM dbo.[user_services] us
+        JOIN dbo.[service] s ON s.id = us.service_id
+        WHERE us.organisation_id = o.id
+          AND s.id = :collectServiceId
+          AND us.status = 1
+      )`;
+
+const pagedListOfCollectOrgsWithoutActiveUsers = async (
+  collectServiceId,
+  pageNumber = 1,
+  pageSize = 25,
+) => {
+  const offset = (pageNumber - 1) * pageSize;
+  const replacements = { collectServiceId, offset, limit: pageSize };
+
+  const dataSql = `
+    SELECT
+      o.id                         AS org_id,
+      o.name                       AS org_name,
+      o.URN                        AS urn,
+      o.EstablishmentNumber        AS establishment_number,
+      o.Category                   AS category,
+      o.Status                     AS status,
+      o.DistrictAdministrativeCode AS local_authority_code,
+      o.ClosedOn                   AS closed_on,
+      (
+        SELECT COUNT(*)
+        FROM dbo.[user_services] us2
+        JOIN dbo.[service] s2 ON s2.id = us2.service_id
+        WHERE us2.organisation_id = o.id
+          AND s2.id = :collectServiceId
+      ) AS total_user_service_records
+    ${collectOrgsWithoutActiveUsersFrom}
+    ORDER BY o.name
+    OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`;
+
+  const countSql = `
+    SELECT COUNT_BIG(1) AS total
+    ${collectOrgsWithoutActiveUsersFrom}`;
+
+  const organisationsPage = await sequelize.query(dataSql, {
+    replacements,
+    type: Sequelize.QueryTypes.SELECT,
+  });
+
+  const [{ total }] = await sequelize.query(countSql, {
+    replacements,
+    type: Sequelize.QueryTypes.SELECT,
+  });
+
+  const totalNumberOfRecords = Number(total);
+  const totalNumberOfPages = Math.ceil(totalNumberOfRecords / pageSize);
+  return {
+    organisations: organisationsPage,
     totalNumberOfPages,
     totalNumberOfRecords,
   };
@@ -2292,6 +2373,7 @@ module.exports = {
   getUsersPendingApprovalByUser,
   getUsersPendingApproval,
   pagedListOfCategory,
+  pagedListOfCollectOrgsWithoutActiveUsers,
   getUsersAssociatedWithOrganisation,
   pagedListOfUsers,
   pagedListOfInvitations,

--- a/src/app/organisations/getCollectOrgsWithoutActiveUsers.js
+++ b/src/app/organisations/getCollectOrgsWithoutActiveUsers.js
@@ -43,11 +43,16 @@ const getCollectOrgsWithoutActiveUsers = async (req, res) => {
           JOIN dbo.[service] s ON s.id = us.service_id
           WHERE s.id = :collectServiceId
         )
-        AND o.id NOT IN (
-          SELECT DISTINCT us.organisation_id
+        AND NOT EXISTS (
+          -- NOT EXISTS rather than NOT IN: user_services.organisation_id has
+          -- no NOT NULL constraint, and NOT IN against a subquery containing
+          -- even one NULL evaluates to UNKNOWN for every row, silently
+          -- returning zero rows for the whole query.
+          SELECT 1
           FROM dbo.[user_services] us
           JOIN dbo.[service] s ON s.id = us.service_id
-          WHERE s.id = :collectServiceId
+          WHERE us.organisation_id = o.id
+            AND s.id = :collectServiceId
             AND us.status = 1
         )
       ORDER BY o.name

--- a/src/app/organisations/getCollectOrgsWithoutActiveUsers.js
+++ b/src/app/organisations/getCollectOrgsWithoutActiveUsers.js
@@ -37,12 +37,6 @@ const getCollectOrgsWithoutActiveUsers = async (req, res) => {
         ) AS active_user_count
       FROM dbo.[organisation] o
       WHERE o.Status = 1
-        AND o.id IN (
-          SELECT DISTINCT us.organisation_id
-          FROM dbo.[user_services] us
-          JOIN dbo.[service] s ON s.id = us.service_id
-          WHERE s.id = :collectServiceId
-        )
         AND NOT EXISTS (
           -- NOT EXISTS rather than NOT IN: user_services.organisation_id has
           -- no NOT NULL constraint, and NOT IN against a subquery containing

--- a/src/app/organisations/getCollectOrgsWithoutActiveUsers.js
+++ b/src/app/organisations/getCollectOrgsWithoutActiveUsers.js
@@ -1,78 +1,42 @@
-const { QueryTypes } = require("sequelize");
-const repository = require("../../infrastructure/repository");
-const logger = require("../../infrastructure/logger");
-const config = require("../../infrastructure/config");
+const logger = require("./../../infrastructure/logger");
+const config = require("./../../infrastructure/config");
+const organisationsStorage = require("./data/organisationsStorage");
+
+const extractNumber = (req, key, defaultValue) => {
+  if (!req.query || req.query[key] === undefined) return defaultValue;
+
+  const num = parseInt(req.query[key], 10);
+  return isNaN(num) ? 0 : num;
+};
 
 const getCollectOrgsWithoutActiveUsers = async (req, res) => {
-  const correlationId = req.get
-    ? req.get("x-correlation-id")
-    : req.headers && req.headers["x-correlation-id"];
+  const correlationId = req.get ? req.get("x-correlation-id") : undefined;
 
   try {
-    const rows = await repository.sequelize.query(
-      `
-      SELECT DISTINCT
-        o.id                      AS org_id,
-        o.name                    AS org_name,
-        o.URN                     AS urn,
-        o.EstablishmentNumber     AS establishment_number,
-        o.Category                AS category,
-        o.Status                  AS status,
-        o.DistrictAdministrativeCode AS local_authority_code,
-        o.ClosedOn                AS closed_on,
-        (
-          SELECT COUNT(*)
-          FROM dbo.[user_services] us2
-          JOIN dbo.[service] s2 ON s2.id = us2.service_id
-          WHERE us2.organisation_id = o.id
-            AND s2.id = :collectServiceId
-        ) AS total_user_service_records,
-        (
-          SELECT COUNT(*)
-          FROM dbo.[user_services] us3
-          JOIN dbo.[service] s3 ON s3.id = us3.service_id
-          WHERE us3.organisation_id = o.id
-            AND s3.id = :collectServiceId
-            AND us3.status = 1
-        ) AS active_user_count
-      FROM dbo.[organisation] o
-      WHERE o.Status = 1
-        -- Only organisation types with a statutory Collect reporting
-        -- obligation: 001 = Establishment (schools, incl. School Census/
-        -- SLASC/EYC submitters), 002 = Local Authority (SEN2/S251/CIN
-        -- returns). Other active DSI categories (training providers,
-        -- software suppliers, government bodies, etc.) have no such
-        -- obligation and would otherwise show up as noise.
-        AND o.Category IN ('001', '002')
-        AND NOT EXISTS (
-          -- NOT EXISTS rather than NOT IN: user_services.organisation_id has
-          -- no NOT NULL constraint, and NOT IN against a subquery containing
-          -- even one NULL evaluates to UNKNOWN for every row, silently
-          -- returning zero rows for the whole query.
-          SELECT 1
-          FROM dbo.[user_services] us
-          JOIN dbo.[service] s ON s.id = us.service_id
-          WHERE us.organisation_id = o.id
-            AND s.id = :collectServiceId
-            AND us.status = 1
-        )
-      ORDER BY o.name
-      `,
-      {
-        replacements: {
-          collectServiceId: config.legacyServices.collectServiceId,
-        },
-        type: QueryTypes.SELECT,
-      },
-    );
+    const pageNumber = extractNumber(req, "page", 1);
+    if (pageNumber < 1)
+      return res.status(400).send("Page number must be greater than 0");
 
-    return res.status(200).json(rows ?? []);
+    const pageSize = extractNumber(req, "pageSize", 25);
+    if (pageSize < 1 || pageSize > 50)
+      return res
+        .status(400)
+        .send("Page size must be between 1 and 50 inclusive");
+
+    const pagedResult =
+      await organisationsStorage.pagedListOfCollectOrgsWithoutActiveUsers(
+        config.legacyServices.collectServiceId,
+        pageNumber,
+        pageSize,
+      );
+
+    return res.status(200).send(pagedResult);
   } catch (e) {
     logger.error(
       `Error fetching COLLECT orgs without active users - ${e.message}`,
       { correlationId, stack: e.stack },
     );
-    return res.status(500).json({ message: "Internal server error" });
+    return res.status(500).send(e.message || "Server error");
   }
 };
 

--- a/src/app/organisations/getCollectOrgsWithoutActiveUsers.js
+++ b/src/app/organisations/getCollectOrgsWithoutActiveUsers.js
@@ -1,0 +1,73 @@
+const { QueryTypes } = require("sequelize");
+const repository = require("../../infrastructure/repository");
+const logger = require("../../infrastructure/logger");
+const config = require("../../infrastructure/config");
+
+const getCollectOrgsWithoutActiveUsers = async (req, res) => {
+  const correlationId = req.get
+    ? req.get("x-correlation-id")
+    : req.headers && req.headers["x-correlation-id"];
+
+  try {
+    const rows = await repository.sequelize.query(
+      `
+      SELECT DISTINCT
+        o.id                      AS org_id,
+        o.name                    AS org_name,
+        o.URN                     AS urn,
+        o.EstablishmentNumber     AS establishment_number,
+        o.Category                AS category,
+        o.Status                  AS status,
+        o.DistrictAdministrativeCode AS local_authority_code,
+        o.ClosedOn                AS closed_on,
+        (
+          SELECT COUNT(*)
+          FROM dbo.[user_services] us2
+          JOIN dbo.[service] s2 ON s2.id = us2.service_id
+          WHERE us2.organisation_id = o.id
+            AND s2.id = :collectServiceId
+        ) AS total_user_service_records,
+        (
+          SELECT COUNT(*)
+          FROM dbo.[user_services] us3
+          JOIN dbo.[service] s3 ON s3.id = us3.service_id
+          WHERE us3.organisation_id = o.id
+            AND s3.id = :collectServiceId
+            AND us3.status = 1
+        ) AS active_user_count
+      FROM dbo.[organisation] o
+      WHERE o.Status = 1
+        AND o.id IN (
+          SELECT DISTINCT us.organisation_id
+          FROM dbo.[user_services] us
+          JOIN dbo.[service] s ON s.id = us.service_id
+          WHERE s.id = :collectServiceId
+        )
+        AND o.id NOT IN (
+          SELECT DISTINCT us.organisation_id
+          FROM dbo.[user_services] us
+          JOIN dbo.[service] s ON s.id = us.service_id
+          WHERE s.id = :collectServiceId
+            AND us.status = 1
+        )
+      ORDER BY o.name
+      `,
+      {
+        replacements: {
+          collectServiceId: config.legacyServices.collectServiceId,
+        },
+        type: QueryTypes.SELECT,
+      },
+    );
+
+    return res.status(200).json(rows ?? []);
+  } catch (e) {
+    logger.error(
+      `Error fetching COLLECT orgs without active users - ${e.message}`,
+      { correlationId, stack: e.stack },
+    );
+    return res.status(500).json({ message: "Internal server error" });
+  }
+};
+
+module.exports = getCollectOrgsWithoutActiveUsers;

--- a/src/app/organisations/getCollectOrgsWithoutActiveUsers.js
+++ b/src/app/organisations/getCollectOrgsWithoutActiveUsers.js
@@ -37,6 +37,13 @@ const getCollectOrgsWithoutActiveUsers = async (req, res) => {
         ) AS active_user_count
       FROM dbo.[organisation] o
       WHERE o.Status = 1
+        -- Only organisation types with a statutory Collect reporting
+        -- obligation: 001 = Establishment (schools, incl. School Census/
+        -- SLASC/EYC submitters), 002 = Local Authority (SEN2/S251/CIN
+        -- returns). Other active DSI categories (training providers,
+        -- software suppliers, government bodies, etc.) have no such
+        -- obligation and would otherwise show up as noise.
+        AND o.Category IN ('001', '002')
         AND NOT EXISTS (
           -- NOT EXISTS rather than NOT IN: user_services.organisation_id has
           -- no NOT NULL constraint, and NOT IN against a subquery containing

--- a/src/app/organisations/getCollectOrgsWithoutActiveUsers.js
+++ b/src/app/organisations/getCollectOrgsWithoutActiveUsers.js
@@ -36,7 +36,10 @@ const getCollectOrgsWithoutActiveUsers = async (req, res) => {
       `Error fetching COLLECT orgs without active users - ${e.message}`,
       { correlationId, stack: e.stack },
     );
-    return res.status(500).send(e.message || "Server error");
+    // Deliberately generic: the detail is in the log with the correlation id.
+    // Sibling handlers return e.message, which can put database detail in a
+    // response body.
+    return res.status(500).json({ message: "Internal server error" });
   }
 };
 

--- a/src/app/organisations/index.js
+++ b/src/app/organisations/index.js
@@ -39,6 +39,7 @@ const getOrgsServicesSubServicesRequests = require("./getOrgsServicesSubServices
 const getAllRequestsTypesAssociatedWithOrgs = require("./getAllRequestsTypesAssociatedWithOrgs");
 const getPendingRequestTypesForApproval = require("./getPendingRequestTypesForApproval");
 const getServiceRequest = require("./getServiceRequest");
+const getCollectOrgsWithoutActiveUsers = require("./getCollectOrgsWithoutActiveUsers");
 
 const router = express.Router();
 
@@ -82,6 +83,10 @@ const routes = () => {
     asyncWrapper(getUsersAssocatedWithOrganisationsForApproval),
   );
   router.get("/:id/users", asyncWrapper(getUsersForOrganisation));
+  router.get(
+    "/collect-without-active-users",
+    asyncWrapper(getCollectOrgsWithoutActiveUsers),
+  );
   router.get("/:id", asyncWrapper(getOrganisation));
   router.get("/v2/:id", asyncWrapper(getOrganisationV2));
   router.put("/:id/users/:uid", asyncWrapper(putUserInOrg));

--- a/src/infrastructure/config/index.js
+++ b/src/infrastructure/config/index.js
@@ -79,6 +79,15 @@ const config = {
   organisationRequests: {
     numberOfDaysUntilOverdue: 5
   },
+  legacyServices: {
+    // Default is the id database_scripts/mssql/014_add_s2s_kts-sa_collect_services.sql
+    // inserts as a hardcoded literal (confirmed against production 2026-07-24). This is
+    // an env override, not a code constant, precisely because this repo has no proven
+    // mechanism guaranteeing that migration has run identically, unmodified, in every
+    // environment - if a different environment's Collect service row ever has a
+    // different id, set COLLECT_SERVICE_ID there rather than changing code.
+    collectServiceId: process.env.COLLECT_SERVICE_ID || "4fd40032-61a6-4beb-a6c4-6b39a3af81c1"
+  },
   schedules: {
     overdueRequests: "0 0 * * *"
   },

--- a/src/infrastructure/config/index.js
+++ b/src/infrastructure/config/index.js
@@ -81,11 +81,13 @@ const config = {
   },
   legacyServices: {
     // Default is the id database_scripts/mssql/014_add_s2s_kts-sa_collect_services.sql
-    // inserts as a hardcoded literal (confirmed against production 2026-07-24). This is
-    // an env override, not a code constant, precisely because this repo has no proven
-    // mechanism guaranteeing that migration has run identically, unmodified, in every
-    // environment - if a different environment's Collect service row ever has a
-    // different id, set COLLECT_SERVICE_ID there rather than changing code.
+    // inserts as a hardcoded literal (confirmed against production 2026-07-24), so every
+    // environment that ran that migration has this exact id - it is not generated per
+    // environment. It stays an env override rather than a code constant because that
+    // migration is guarded by IF NOT EXISTS: an environment whose Collect service row
+    // predates it, or was created by hand, would silently keep a different id. If the
+    // report returns nothing where rows are expected, check the id there first and set
+    // COLLECT_SERVICE_ID rather than changing code.
     collectServiceId: process.env.COLLECT_SERVICE_ID || "4fd40032-61a6-4beb-a6c4-6b39a3af81c1"
   },
   schedules: {

--- a/src/infrastructure/config/schema.js
+++ b/src/infrastructure/config/schema.js
@@ -33,6 +33,10 @@ const organisationRequestsSchema = new SimpleSchema({
   },
 });
 
+const legacyServicesSchema = new SimpleSchema({
+  collectServiceId: String,
+});
+
 const schema = new SimpleSchema({
   loggerSettings: schemas.loggerSettings,
   hostingEnvironment: schemas.hostingEnvironment,
@@ -49,6 +53,7 @@ const schema = new SimpleSchema({
     type: organisationRequestsSchema,
     optional: true,
   },
+  legacyServices: legacyServicesSchema,
 });
 module.exports.validate = () => {
   validateConfigAgainstSchema(config, schema, logger)

--- a/test/appTests/organisationsTests/data/organisationStorage.pagedListOfCollectOrgsWithoutActiveUsers.test.js
+++ b/test/appTests/organisationsTests/data/organisationStorage.pagedListOfCollectOrgsWithoutActiveUsers.test.js
@@ -1,0 +1,85 @@
+const mockQuery = jest.fn();
+
+jest.mock("./../../../../src/infrastructure/logger", () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+}));
+
+jest.mock("./../../../../src/infrastructure/repository", () => ({
+  sequelize: { query: mockQuery },
+}));
+
+const {
+  pagedListOfCollectOrgsWithoutActiveUsers,
+} = require("./../../../../src/app/organisations/data/organisationsStorage");
+
+const collectServiceId = "collect-service-id";
+const orgRow = { org_id: "org-1", org_name: "Test School" };
+
+const dataSqlOf = (call) => call[0];
+const replacementsOf = (call) => call[1].replacements;
+
+describe("When listing Collect organisations without active users", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    // First call is the page of rows, second is the count.
+    mockQuery
+      .mockResolvedValueOnce([orgRow])
+      .mockResolvedValueOnce([{ total: 6083 }]);
+  });
+
+  it("returns the rows with the total record and page counts", async () => {
+    const result = await pagedListOfCollectOrgsWithoutActiveUsers(
+      collectServiceId,
+      1,
+      25,
+    );
+
+    expect(result).toEqual({
+      organisations: [orgRow],
+      totalNumberOfPages: 244,
+      totalNumberOfRecords: 6083,
+    });
+  });
+
+  it("offsets by the requested page", async () => {
+    await pagedListOfCollectOrgsWithoutActiveUsers(collectServiceId, 3, 25);
+
+    expect(replacementsOf(mockQuery.mock.calls[0])).toEqual({
+      collectServiceId,
+      offset: 50,
+      limit: 25,
+    });
+  });
+
+  it("treats a user as covering the organisation only when the user is active too", async () => {
+    // Deactivating a user changes only the user record - their user_services
+    // row stays active. Checking the access row alone would hide exactly the
+    // organisations this report exists to surface.
+    await pagedListOfCollectOrgsWithoutActiveUsers(collectServiceId, 1, 25);
+
+    const sql = dataSqlOf(mockQuery.mock.calls[0]);
+    expect(sql).toContain("JOIN dbo.[user] u ON u.sub = us.user_id");
+    expect(sql).toContain("AND us.status = 1");
+    expect(sql).toContain("AND u.status = 1");
+  });
+
+  it("restricts to the Collect-eligible organisation categories", async () => {
+    await pagedListOfCollectOrgsWithoutActiveUsers(collectServiceId, 1, 25);
+
+    expect(dataSqlOf(mockQuery.mock.calls[0])).toContain(
+      "o.Category IN ('001', '002')",
+    );
+  });
+
+  it("counts against the same filter as the page of rows", async () => {
+    await pagedListOfCollectOrgsWithoutActiveUsers(collectServiceId, 1, 25);
+
+    const [dataCall, countCall] = mockQuery.mock.calls;
+    expect(dataSqlOf(countCall)).toContain("COUNT_BIG(1)");
+    // Both queries share one FROM/WHERE fragment, so the filters cannot drift.
+    expect(dataSqlOf(dataCall)).toContain("NOT EXISTS");
+    expect(dataSqlOf(countCall)).toContain("NOT EXISTS");
+  });
+});

--- a/test/appTests/organisationsTests/getCollectOrgsWithoutActiveUsers.test.js
+++ b/test/appTests/organisationsTests/getCollectOrgsWithoutActiveUsers.test.js
@@ -27,6 +27,7 @@ describe("getCollectOrgsWithoutActiveUsers", () => {
     res = {
       status: jest.fn().mockReturnThis(),
       send: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
     };
     pagedList.mockReset().mockResolvedValue(emptyPage);
   });
@@ -92,5 +93,16 @@ describe("getCollectOrgsWithoutActiveUsers", () => {
     await getCollectOrgsWithoutActiveUsers(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it("does not put the underlying error detail in the 500 response", async () => {
+    pagedList.mockRejectedValue(
+      new Error("Invalid column name 'DistrictAdministrativeCode'"),
+    );
+
+    await getCollectOrgsWithoutActiveUsers(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({ message: "Internal server error" });
+    expect(JSON.stringify(res.json.mock.calls)).not.toContain("Invalid column");
   });
 });

--- a/test/appTests/organisationsTests/getCollectOrgsWithoutActiveUsers.test.js
+++ b/test/appTests/organisationsTests/getCollectOrgsWithoutActiveUsers.test.js
@@ -1,7 +1,5 @@
-const mockQuery = jest.fn();
-
-jest.mock("./../../../src/infrastructure/repository", () => ({
-  sequelize: { query: mockQuery },
+jest.mock("./../../../src/app/organisations/data/organisationsStorage", () => ({
+  pagedListOfCollectOrgsWithoutActiveUsers: jest.fn(),
 }));
 jest.mock("./../../../src/infrastructure/logger", () => ({
   error: jest.fn(),
@@ -10,54 +8,89 @@ jest.mock("./../../../src/infrastructure/config", () => ({
   legacyServices: { collectServiceId: "test-collect-service-id" },
 }));
 
+const organisationsStorage = require("./../../../src/app/organisations/data/organisationsStorage");
 const getCollectOrgsWithoutActiveUsers = require("./../../../src/app/organisations/getCollectOrgsWithoutActiveUsers");
+
+const pagedList = organisationsStorage.pagedListOfCollectOrgsWithoutActiveUsers;
+
+const emptyPage = {
+  organisations: [],
+  totalNumberOfPages: 0,
+  totalNumberOfRecords: 0,
+};
 
 describe("getCollectOrgsWithoutActiveUsers", () => {
   let req, res;
 
   beforeEach(() => {
-    req = { headers: { "x-correlation-id": "corr-1" } };
-    res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
-    mockQuery.mockClear();
+    req = { query: {}, get: jest.fn().mockReturnValue("corr-1") };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    };
+    pagedList.mockReset().mockResolvedValue(emptyPage);
   });
 
-  it("returns 200 with the query result", async () => {
-    const orgs = [{ org_id: "org-1", org_name: "Test School", urn: "123456" }];
-    mockQuery.mockResolvedValue(orgs);
+  it("returns 200 with the paged result", async () => {
+    const page = {
+      organisations: [
+        { org_id: "org-1", org_name: "Test School", urn: "123456" },
+      ],
+      totalNumberOfPages: 1,
+      totalNumberOfRecords: 1,
+    };
+    pagedList.mockResolvedValue(page);
 
     await getCollectOrgsWithoutActiveUsers(req, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(orgs);
+    expect(res.send).toHaveBeenCalledWith(page);
   });
 
-  it("returns 200 with an empty array when no gap orgs exist", async () => {
-    mockQuery.mockResolvedValue([]);
-
+  it("returns 200 with an empty page when no gap orgs exist", async () => {
     await getCollectOrgsWithoutActiveUsers(req, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith([]);
+    expect(res.send).toHaveBeenCalledWith(emptyPage);
   });
 
-  it("returns 500 when the query throws", async () => {
-    mockQuery.mockRejectedValue(new Error("DB error"));
+  it("defaults to page 1 with a page size of 25", async () => {
+    await getCollectOrgsWithoutActiveUsers(req, res);
+
+    expect(pagedList).toHaveBeenCalledWith("test-collect-service-id", 1, 25);
+  });
+
+  it("passes the requested page and page size through", async () => {
+    req.query = { page: "3", pageSize: "50" };
+
+    await getCollectOrgsWithoutActiveUsers(req, res);
+
+    expect(pagedList).toHaveBeenCalledWith("test-collect-service-id", 3, 50);
+  });
+
+  it("returns 400 when the page number is below 1", async () => {
+    req.query = { page: "0" };
+
+    await getCollectOrgsWithoutActiveUsers(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(pagedList).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the page size is above 50", async () => {
+    req.query = { pageSize: "51" };
+
+    await getCollectOrgsWithoutActiveUsers(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(pagedList).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the storage call throws", async () => {
+    pagedList.mockRejectedValue(new Error("DB error"));
 
     await getCollectOrgsWithoutActiveUsers(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
-  });
-
-  it("binds the configured collect service id as a query replacement", async () => {
-    mockQuery.mockResolvedValue([]);
-
-    await getCollectOrgsWithoutActiveUsers(req, res);
-
-    expect(mockQuery).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        replacements: { collectServiceId: "test-collect-service-id" },
-      }),
-    );
   });
 });

--- a/test/appTests/organisationsTests/getCollectOrgsWithoutActiveUsers.test.js
+++ b/test/appTests/organisationsTests/getCollectOrgsWithoutActiveUsers.test.js
@@ -1,0 +1,63 @@
+const mockQuery = jest.fn();
+
+jest.mock("./../../../src/infrastructure/repository", () => ({
+  sequelize: { query: mockQuery },
+}));
+jest.mock("./../../../src/infrastructure/logger", () => ({
+  error: jest.fn(),
+}));
+jest.mock("./../../../src/infrastructure/config", () => ({
+  legacyServices: { collectServiceId: "test-collect-service-id" },
+}));
+
+const getCollectOrgsWithoutActiveUsers = require("./../../../src/app/organisations/getCollectOrgsWithoutActiveUsers");
+
+describe("getCollectOrgsWithoutActiveUsers", () => {
+  let req, res;
+
+  beforeEach(() => {
+    req = { headers: { "x-correlation-id": "corr-1" } };
+    res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    mockQuery.mockClear();
+  });
+
+  it("returns 200 with the query result", async () => {
+    const orgs = [{ org_id: "org-1", org_name: "Test School", urn: "123456" }];
+    mockQuery.mockResolvedValue(orgs);
+
+    await getCollectOrgsWithoutActiveUsers(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(orgs);
+  });
+
+  it("returns 200 with an empty array when no gap orgs exist", async () => {
+    mockQuery.mockResolvedValue([]);
+
+    await getCollectOrgsWithoutActiveUsers(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith([]);
+  });
+
+  it("returns 500 when the query throws", async () => {
+    mockQuery.mockRejectedValue(new Error("DB error"));
+
+    await getCollectOrgsWithoutActiveUsers(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it("binds the configured collect service id as a query replacement", async () => {
+    mockQuery.mockResolvedValue([]);
+
+    await getCollectOrgsWithoutActiveUsers(req, res);
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        replacements: { collectServiceId: "test-collect-service-id" },
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Fresh branch/PR replacing #403 (which itself replaced #397) - both carried leftover commit history from the old NSA-9314 branch. Single clean commit history on top of current main.

## Summary
- New read-only endpoint returning organisations that currently have zero active COLLECT users - including organisations that have never had any COLLECT access at all, not just ones that had it and lost it. Per the ticket's own wording ("organisations we are expecting to receive data from that don't have any users with access via DSI"), this is a "no active access" check, not a "had access, now inactive" check.
- Filtered to organisation categories `001` (Establishment/schools) and `002` (Local Authority) - the two categories confirmed by the data-collections team as having a statutory Collect reporting obligation. Verified live against production: 6,083 results (5,979 schools, 104 LAs), vs 44,001 unfiltered / 0 under the original narrow "had access, now inactive" definition.
- Route registered before `/:id` to prevent Express routing conflicts
- Collect service id sourced from `config.legacyServices.collectServiceId` (`COLLECT_SERVICE_ID` env var, falling back to the confirmed production value) rather than hardcoded, since this repo has no proven guarantee the id-inserting migration has run identically across every environment
- SQL uses Sequelize named replacements rather than string interpolation
- "No active users" filter uses `NOT EXISTS` rather than `NOT IN`, since `user_services.organisation_id` is nullable and `NOT IN` against a subquery containing a NULL silently returns zero rows for the whole query

## Test plan
- [x] CI: 252 tests pass
- [x] Verified live against production: sample rows spot-checked against raw `user_services` data (both a true-positive "never had access" org and a true-negative "has an active user" org, confirmed correctly included/excluded respectively)
- [ ] PP: validate the result set with the COLLECT team before surfacing in the report UI